### PR TITLE
アカウント削除をできないようにする

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -26,9 +26,9 @@ module Users
     # end
 
     # DELETE /resource
-    # def destroy
-    #   super
-    # end
+    def destroy
+      redirect_to edit_user_registration_path, alert: 'アカウントの削除は許可されていません'
+    end
 
     # GET /resource/cancel
     # Forces the session data which is usually expired after sign

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -42,13 +42,4 @@
       <%= link_to t('devise.shared.links.back'), :back, class: 'py-2.5 px-5 mr-2 mb-2 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-200' %>
     </div>
   <% end %>
-
-  <h3 class="mt-5 font-bold text-xl"><%= t('.cancel_my_account') %></h3>
-
-  <div class="my-4">
-    <%= t('.unhappy') %>
-    <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure'), turbo_confirm: t('.are_you_sure') }, method: :delete, class: 'focus:outline-none text-white bg-red-700 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 mr-2 my-2' %>
-  </div>
-
-  <%= link_to t('devise.shared.links.back'), :back, class: 'py-2.5 px-5 mr-2 mb-2 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-200' %>
 </div>


### PR DESCRIPTION
- #22

削除ボタンの削除 && destroyアクションが呼ばれたとき、トップにリダイレクトするようにした
最下部の戻るボタンが不要になったので削除
